### PR TITLE
Add filter for Download PublicKeys

### DIFF
--- a/src/main/java/app/coronawarn/dcc/controller/ExternalDccClaimController.java
+++ b/src/main/java/app/coronawarn/dcc/controller/ExternalDccClaimController.java
@@ -99,12 +99,12 @@ public class ExternalDccClaimController {
           "Registration Token does not exist/ is not registered at DCC-Server."));
 
     // DCC Pending
-    if (dccRegistration.getEncryptedDataEncryptionKey() == null && dccRegistration.getDcc() == null) {
+    if (dccRegistration.getDccHash() == null && dccRegistration.getDcc() == null) {
       return ResponseEntity.status(HttpStatus.ACCEPTED).build();
     }
 
     // DCC already cleaned up
-    if (dccRegistration.getEncryptedDataEncryptionKey() != null && dccRegistration.getDcc() == null) {
+    if (dccRegistration.getDccHash() != null && dccRegistration.getDcc() == null) {
       throw new DccServerException(HttpStatus.GONE, "DCC already cleaned up.");
     }
 

--- a/src/main/java/app/coronawarn/dcc/controller/InternalPublicKeyController.java
+++ b/src/main/java/app/coronawarn/dcc/controller/InternalPublicKeyController.java
@@ -72,7 +72,7 @@ public class InternalPublicKeyController {
   public ResponseEntity<List<LabPublicKeyInfo>> searchPublicKeys(
     @PathVariable("labId") String labId) {
 
-    List<LabPublicKeyInfo> resultList = dccRegistrationService.findByLabId(labId).stream()
+    List<LabPublicKeyInfo> resultList = dccRegistrationService.findPendingDccByLabId(labId).stream()
       .map(this::convert)
       .collect(Collectors.toList());
 

--- a/src/main/java/app/coronawarn/dcc/repository/DccRegistrationRepository.java
+++ b/src/main/java/app/coronawarn/dcc/repository/DccRegistrationRepository.java
@@ -31,7 +31,7 @@ public interface DccRegistrationRepository extends JpaRepository<DccRegistration
 
   Optional<DccRegistration> findByRegistrationToken(String registrationToken);
 
-  List<DccRegistration> findByLabId(String labId);
+  List<DccRegistration> findByLabIdAndDccHashIsNull(String labId);
 
   Optional<DccRegistration> findByHashedGuid(String hashedGuid);
 }

--- a/src/main/java/app/coronawarn/dcc/service/DccRegistrationService.java
+++ b/src/main/java/app/coronawarn/dcc/service/DccRegistrationService.java
@@ -78,13 +78,13 @@ public class DccRegistrationService {
   }
 
   /**
-   * Queires the database for DCC Registrations by Lab ID.
+   * Queries the database for DCC Registrations without signed DCC by Lab ID.
    *
    * @param labId labId to search for.
    * @return List of matching DCC Registrations.
    */
-  public List<DccRegistration> findByLabId(String labId) {
-    return dccRegistrationRepository.findByLabId(labId);
+  public List<DccRegistration> findPendingDccByLabId(String labId) {
+    return dccRegistrationRepository.findByLabIdAndDccHashIsNull(labId);
   }
 
   /**


### PR DESCRIPTION
This PR adds a filter to download PublicKeys endpoint to only submit PublicKeys of Tests which do not have a dcc.