### PR TITLE
fix: Increase maximum size of encrypted DEK

### DIFF
--- a/src/main/java/app/coronawarn/dcc/model/DccUploadRequest.java
+++ b/src/main/java/app/coronawarn/dcc/model/DccUploadRequest.java
@@ -50,7 +50,7 @@ public class DccUploadRequest {
 
   @Schema(description = "Base64 encoded with PublicKey encrypted Data Encryption Key for encrypted DCC.")
   @Pattern(regexp = "^[A-Za-z0-9+/=]*$")
-  @Size(max = 255)
+  @Size(max = 600)
   @NotNull
   @NotEmpty
   private String dataEncryptionKey;

--- a/src/main/resources/db/changelog.yml
+++ b/src/main/resources/db/changelog.yml
@@ -11,3 +11,6 @@ databaseChangeLog:
   - include:
       file: changelog/v003-add-partner-id-column.yml
       relativeToChangelogFile: true
+  - include:
+      file: changelog/v004-increase-dek-column-size.yml
+      relativeToChangelogFile: true

--- a/src/main/resources/db/changelog/v004-increase-dek-column-size.yml
+++ b/src/main/resources/db/changelog/v004-increase-dek-column-size.yml
@@ -1,0 +1,9 @@
+databaseChangeLog:
+  - changeSet:
+      id: increase-dek-column-size
+      author: f11h
+      changes:
+        - modifyDataType:
+            tableName: dcc_registration
+            columnName: encrypted_data_encryption_key
+            newDataType: varchar(600)


### PR DESCRIPTION
The property encrypted Data Encryption Key is to small. This PR increases the size to a maximum of 600 characters.