### PR TITLE
LabId Pinning

### DIFF
--- a/api-docs.json
+++ b/api-docs.json
@@ -15,68 +15,19 @@
     }
   ],
   "paths": {
-    "/version/v1/publicKey": {
-      "post": {
-        "tags": [
-          "public-key-controller"
-        ],
-        "summary": "Upload a Public Key",
-        "description": "Uploads a Public Key to a Registration Token from Verification Server to generate Digital Covid Certificate data.",
-        "operationId": "uploadPublicKey",
-        "parameters": [
-          {
-            "name": "cwa-fake",
-            "in": "header",
-            "required": false,
-            "schema": {
-              "type": "string"
-            }
-          }
-        ],
-        "requestBody": {
-          "content": {
-            "application/json": {
-              "schema": {
-                "$ref": "#/components/schemas/UploadPublicKeyRequest"
-              }
-            }
-          },
-          "required": true
-        },
-        "responses": {
-          "201": {
-            "description": "Public Key uploaded and associated."
-          },
-          "400": {
-            "description": "Bad Request. (e.g. Wrong Format of RegistrationToken or PublicKey)."
-          },
-          "403": {
-            "description": "RegistrationToken is not allowed to issue a DCC (e.g. Token is issued for TeleTan)."
-          },
-          "404": {
-            "description": "RegistrationToken does not exists."
-          },
-          "409": {
-            "description": "RegistrationToken is already assigned with a PublicKey."
-          },
-          "500": {
-            "description": "Internal Server Error"
-          }
-        }
-      }
-    },
     "/version/v1/dcc": {
       "post": {
         "tags": [
-          "dcc-claim-controller"
+          "external"
         ],
         "summary": "COVID-19 Test Result DCC Components",
         "description": "Gets the components to build a Digital Covid Certificate with the result of COVID-19 Test.",
-        "operationId": "getDccComponents",
+        "operationId": "claimDcc",
         "parameters": [
           {
             "name": "cwa-fake",
             "in": "header",
+            "description": "Flag whether this request should be handled as fake request",
             "required": false,
             "schema": {
               "type": "string"
@@ -94,10 +45,29 @@
           "required": true
         },
         "responses": {
-          "200": {
-            "description": "DCC Components retrieved",
+          "400": {
+            "description": "Bad Request. (Invalid RegistrationToken format)"
+          },
+          "500": {
+            "description": "Internal Server Error",
             "content": {
               "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/DccUnexpectedError"
+                }
+              }
+            }
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "200": {
+            "description": "DCC Components retrieved.",
+            "content": {
+              "*/*": {
                 "schema": {
                   "$ref": "#/components/schemas/DccResponse"
                 }
@@ -105,35 +75,164 @@
             }
           },
           "202": {
-            "description": "DCC is pending."
-          },
-          "400": {
-            "description": "Bad Request. (Invalid RegistrationToken format)"
+            "description": "DCC is pending.",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/DccDownloadResponse"
+                }
+              }
+            }
           },
           "404": {
-            "description": "Registration Token does not exist/ is not registered at DCC-Server."
+            "description": "Registration Token does not exist/ is not registered at DCC-Server.",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/DccDownloadResponse"
+                }
+              }
+            }
           },
           "410": {
-            "description": "DCC already cleaned up."
+            "description": "DCC already cleaned up.",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/DccDownloadResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/version/v1/test/{testId}/dcc": {
+      "post": {
+        "tags": [
+          "internal"
+        ],
+        "summary": "Upload a DCC for a test.",
+        "description": "Endpoint to upload components to build the DCC.",
+        "operationId": "uploadDcc",
+        "parameters": [
+          {
+            "name": "testId",
+            "in": "path",
+            "description": "ID of the test (hashed GUID).",
+            "required": true,
+            "schema": {
+              "pattern": "^[XxA-Fa-f0-9]([A-Fa-f0-9]{63})$",
+              "type": "string"
+            }
           },
-          "412": {
-            "description": "TestResult not yet received."
+          {
+            "name": "X-CWA-PARTNER-ID",
+            "in": "header",
+            "description": "PartnerID. This needs only to be set if DCC-Server is contacted without DCC-Proxy in between.",
+            "required": true,
+            "schema": {
+              "pattern": "^[A-Za-z0-9]{1,64}$",
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/DccUploadRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "400": {
+            "description": "Invalid Data format"
           },
           "500": {
-            "description": "Internal Server Error",
+            "description": "Internal Server Error"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "201": {
+            "description": "DCC created",
             "content": {
               "application/json": {
                 "schema": {
-                  "properties": {
-                    "reason": {
-                      "type": "string",
-                      "enum": [
-                        "SIGNING_CLIENT_ERROR",
-                        "SIGNING_SERVER_ERROR",
-                        "LAB_INVALID_RESPONSE",
-                        "INTERNAL"
-                      ]
-                    }
+                  "$ref": "#/components/schemas/DccUploadResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Test does not exists",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/DccUploadResponse"
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "DCC already exists",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/DccUploadResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/version/v1/publicKey/search/{labId}": {
+      "get": {
+        "tags": [
+          "internal"
+        ],
+        "summary": "Search Public Keys and Test Ids for given LabId",
+        "description": "Endpoint to search and download all PublicKeys which are assigned to a testId and the given lab Id.",
+        "operationId": "searchPublicKeys",
+        "parameters": [
+          {
+            "name": "labId",
+            "in": "path",
+            "description": "ID of the laboratory to search for.",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "400": {
+            "description": "Bad Request"
+          },
+          "500": {
+            "description": "Internal Server Error"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "200": {
+            "description": "Public Key list returned.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "array",
+                  "items": {
+                    "$ref": "#/components/schemas/LabPublicKeyInfo"
                   }
                 }
               }
@@ -141,28 +240,67 @@
           }
         }
       }
+    },
+    "/version/v1/publicKey": {
+      "post": {
+        "tags": [
+          "external"
+        ],
+        "summary": "Upload a Public Key",
+        "description": "Uploads a Public Key to a Registration Token from Verification Server to generate Digital Covid Certificate data.",
+        "operationId": "uploadPublicKey",
+        "parameters": [
+          {
+            "name": "cwa-fake",
+            "in": "header",
+            "description": "Flag whether this request should be handled as fake request",
+            "required": false,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/UploadPublicKeyRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "400": {
+            "description": "Bad Request. (e.g. Wrong Format of RegistrationToken or PublicKey)."
+          },
+          "500": {
+            "description": "Internal Server Error"
+          },
+          "415": {
+            "description": "Unsupported Media Type"
+          },
+          "405": {
+            "description": "Method Not Allowed"
+          },
+          "201": {
+            "description": "Public Key uploaded and associated."
+          },
+          "403": {
+            "description": "RegistrationToken is not allowed to issue a DCC (e.g. Token is issued for TeleTan)."
+          },
+          "404": {
+            "description": "RegistrationToken does not exists."
+          },
+          "409": {
+            "description": "RegistrationToken is already assigned with a PublicKey."
+          }
+        }
+      }
     }
   },
   "components": {
     "schemas": {
-      "UploadPublicKeyRequest": {
-        "type": "object",
-        "required": [
-          "registrationToken",
-          "publicKey"
-        ],
-        "properties": {
-          "registrationToken": {
-            "type": "string",
-            "description": "registrationToken from Verification Server"
-          },
-          "publicKey": {
-            "type": "string",
-            "description": "Base64 encoded public key in DER format to encrypt DCC payload components."
-          }
-        },
-        "description": "The upload Public Key request model."
-      },
       "RegistrationToken": {
         "required": [
           "registrationToken"
@@ -171,7 +309,8 @@
         "properties": {
           "registrationToken": {
             "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89aAbB][a-f0-9]{3}-[a-f0-9]{12}$",
-            "type": "string"
+            "type": "string",
+            "description": "registrationToken from Verification Server"
           }
         },
         "description": "The registration token model."
@@ -181,13 +320,124 @@
         "properties": {
           "dek": {
             "type": "string",
-            "description": "Data Encryption Key (Encrypted AES-256 Key, encrypted with uploaders public key)"
+            "description": "Data Encryption Key (Encrypted AES-256 Key, encrypted with uploaders public key"
           },
           "dcc": {
             "type": "string",
             "description": "Base64 encoded DCC COSE Object. Payload is encrypted with data encryption key."
           }
-        }
+        },
+        "description": "The Dcc Response Model."
+      },
+      "DccUnexpectedError": {
+        "type": "object",
+        "properties": {
+          "reason": {
+            "type": "string",
+            "description": "Reason of failure.",
+            "enum": [
+              "SIGNING_CLIENT_ERROR",
+              "SIGNING_SERVER_ERROR",
+              "LAB_INVALID_RESPONSE",
+              "INTERNAL"
+            ]
+          }
+        },
+        "description": "The DCC Unexpected Error model. Holds the error which has occured during creation of DCC."
+      },
+      "DccDownloadResponse": {
+        "type": "object",
+        "properties": {
+          "dek": {
+            "type": "string",
+            "description": "Base64 encoded Data Encryption Key (Encrypted AES-256 Key, encrypted with uploaders public key)"
+          },
+          "dcc": {
+            "type": "string",
+            "description": "Base64 encoded DCC COSE_SIGN1 Object. Payload is encrypted with data encryption key."
+          }
+        },
+        "description": "Response with DCC data."
+      },
+      "DccUploadRequest": {
+        "required": [
+          "dataEncryptionKey",
+          "encryptedDcc"
+        ],
+        "type": "object",
+        "properties": {
+          "dccHash": {
+            "pattern": "^[A-Fa-f0-9]{64}$",
+            "type": "string",
+            "description": "SHA256 Hash of plain DCC payload."
+          },
+          "encryptedDcc": {
+            "maxLength": 1000,
+            "minLength": 0,
+            "pattern": "^[A-Za-z0-9+/=]*$",
+            "type": "string",
+            "description": "Base64 encoded encrypted DCC payload."
+          },
+          "dataEncryptionKey": {
+            "maxLength": 255,
+            "minLength": 0,
+            "pattern": "^[A-Za-z0-9+/=]*$",
+            "type": "string",
+            "description": "Base64 encoded with PublicKey encrypted Data Encryption Key for encrypted DCC."
+          }
+        },
+        "description": "Request payload to upload a DCC from laboratory."
+      },
+      "DccUploadResponse": {
+        "type": "object",
+        "properties": {
+          "partialDcc": {
+            "type": "string",
+            "description": "Base64 encoded DCC Structure without the payload. (COSE/CBOR, Payload needs to be replaced by laboratory)"
+          }
+        },
+        "description": "Response for uploaded DCC data."
+      },
+      "LabPublicKeyInfo": {
+        "type": "object",
+        "properties": {
+          "testId": {
+            "type": "string",
+            "description": "Hashed GUID of the test."
+          },
+          "dcci": {
+            "type": "string",
+            "description": "The DCCI of the to be created DCC."
+          },
+          "publicKey": {
+            "type": "string",
+            "description": "The PublicKey to encrypt the Data Encryption Key with.",
+            "format": "Base64 encoded X509 SubjectPublicKeyInformation Object (RSA or EC Key)"
+          }
+        },
+        "description": "Information a lab receives when searching for PublicKeys"
+      },
+      "UploadPublicKeyRequest": {
+        "required": [
+          "publicKey",
+          "registrationToken"
+        ],
+        "type": "object",
+        "properties": {
+          "registrationToken": {
+            "pattern": "^[a-f0-9]{8}-[a-f0-9]{4}-4[a-f0-9]{3}-[89aAbB][a-f0-9]{3}-[a-f0-9]{12}$",
+            "type": "string",
+            "description": "registrationToken from Verification Server"
+          },
+          "publicKey": {
+            "type": "string",
+            "description": "Base64 encoded public key in DER format to encrypt DCC payload components."
+          },
+          "responsePadding": {
+            "type": "string"
+          }
+        },
+        "description": "Request payload to upload a Public Key."
       }
     }
   }

--- a/src/main/java/app/coronawarn/dcc/config/DccApplicationConfig.java
+++ b/src/main/java/app/coronawarn/dcc/config/DccApplicationConfig.java
@@ -44,6 +44,23 @@ public class DccApplicationConfig {
 
   private String dcciPrefix;
 
+  private LabIdClaim labIdClaim = new LabIdClaim();
+
+  @Getter
+  @Setter
+  public static class LabIdClaim {
+
+    /**
+     * Maximum age of a LabId Claim in days after last usage of the claimed LabId.
+     */
+    private int maximumAge = 30;
+
+    /**
+     * Maximum number of LabIds a partner is able to claim.
+     */
+    private int claimsPerPartner = 5;
+  }
+
   /**
    * Entity Cleanup configuration.
    */

--- a/src/main/java/app/coronawarn/dcc/controller/InternalLabIdClaimController.java
+++ b/src/main/java/app/coronawarn/dcc/controller/InternalLabIdClaimController.java
@@ -1,0 +1,116 @@
+/*-
+ * ---license-start
+ * Corona-Warn-App / cwa-dcc
+ * ---
+ * Copyright (C) 2020 - 2021 T-Systems International GmbH and all other contributors
+ * ---
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ---license-end
+ */
+
+package app.coronawarn.dcc.controller;
+
+import app.coronawarn.dcc.domain.LabIdClaim;
+import app.coronawarn.dcc.model.LabIdClaimRequest;
+import app.coronawarn.dcc.service.LabIdClaimService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.headers.Header;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.parameters.RequestBody;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import java.util.Optional;
+import javax.validation.Valid;
+import javax.validation.constraints.Pattern;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Profile("internal")
+@RestController
+@RequestMapping("/version/v1/labId")
+@RequiredArgsConstructor
+@Validated
+public class InternalLabIdClaimController {
+
+  private final LabIdClaimService labIdClaimService;
+
+  private static final String REMAINING_LAB_ID_HEADER = "X-CWA-REMAINING-LAB-ID";
+
+  /**
+   * Endpoint for claiming a LabId.
+   */
+  @Operation(
+    summary = "Claims a new LabId for partner.",
+    description = "Checks if the given LabId is not in use and creates a claim to associate it with the partner.",
+    tags = {"internal"},
+    parameters = {
+      @Parameter(name = "X-CWA-PARTNER-ID", in = ParameterIn.HEADER, description = "PartnerID. This needs only to be"
+        + " set if DCC-Server is contacted without DCC-Proxy in between.")
+    },
+    requestBody = @RequestBody(content = @Content(schema = @Schema(implementation = LabIdClaimRequest.class))),
+    responses = {
+      @ApiResponse(
+        responseCode = "204",
+        description = "LabId is claimed to you.",
+        headers = @Header(
+          name = REMAINING_LAB_ID_HEADER,
+          description = "Amount of remaining LabIds which can be claimed by partner")),
+      @ApiResponse(responseCode = "400", description = "Invalid LabId format"),
+      @ApiResponse(responseCode = "403", description = "LabId Quota is exceeded by partner."),
+      @ApiResponse(responseCode = "409", description = "LabId is already used by another partner."),
+      @ApiResponse(responseCode = "500", description = "Internal Server Error")
+    })
+  @PostMapping("")
+  public ResponseEntity<Void> claimLabId(
+    @Valid @Pattern(regexp = "^[A-Za-z0-9]{1,64}$") @RequestHeader("X-CWA-PARTNER-ID") String partnerId,
+    @Valid @org.springframework.web.bind.annotation.RequestBody LabIdClaimRequest claimRequest) {
+
+    Optional<LabIdClaim> claim = labIdClaimService.getClaimEntity(claimRequest.getLabId());
+
+    // LabId is claimed by another partner.
+    if (claim.isPresent() && !claim.get().getPartnerId().equals(partnerId)) {
+      return ResponseEntity
+        .status(HttpStatus.CONFLICT)
+        .build();
+    }
+
+    int remainingClaims = labIdClaimService.getRemainingClaims(partnerId);
+
+    // Quota exceeded
+    if (claim.isEmpty() && remainingClaims <= 0) {
+      return ResponseEntity
+        .status(HttpStatus.FORBIDDEN)
+        .build();
+    }
+
+    // Everything is ok. Create the claim or just get it to update last used property.
+    labIdClaimService.getClaim(partnerId, claimRequest.getLabId());
+
+    // update remaining Claims
+    remainingClaims = labIdClaimService.getRemainingClaims(partnerId);
+
+    return ResponseEntity
+      .status(HttpStatus.NO_CONTENT)
+      .header(REMAINING_LAB_ID_HEADER, String.valueOf(remainingClaims))
+      .build();
+  }
+}

--- a/src/main/java/app/coronawarn/dcc/controller/InternalPublicKeyController.java
+++ b/src/main/java/app/coronawarn/dcc/controller/InternalPublicKeyController.java
@@ -21,8 +21,10 @@
 package app.coronawarn.dcc.controller;
 
 import app.coronawarn.dcc.domain.DccRegistration;
+import app.coronawarn.dcc.exception.DccServerException;
 import app.coronawarn.dcc.model.LabPublicKeyInfo;
 import app.coronawarn.dcc.service.DccRegistrationService;
+import app.coronawarn.dcc.service.LabIdClaimService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.enums.ParameterIn;
@@ -32,12 +34,16 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import java.util.List;
 import java.util.stream.Collectors;
+import javax.validation.Valid;
+import javax.validation.constraints.Pattern;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -49,6 +55,8 @@ public class InternalPublicKeyController {
 
   private final DccRegistrationService dccRegistrationService;
 
+  private final LabIdClaimService labIdClaimService;
+
   /**
    * Endpoint for inserting new DCC Registrations.
    */
@@ -57,6 +65,8 @@ public class InternalPublicKeyController {
     description = "Endpoint to search and download all PublicKeys which are assigned to a testId and the given lab Id.",
     tags = {"internal"},
     parameters = {
+      @Parameter(name = "X-CWA-PARTNER-ID", in = ParameterIn.HEADER, description = "PartnerID. This needs only to be"
+        + " set if DCC-Server is contacted without DCC-Proxy in between."),
       @Parameter(name = "labId", in = ParameterIn.PATH, description = "ID of the laboratory to search for.")
     },
     responses = {
@@ -66,11 +76,17 @@ public class InternalPublicKeyController {
         content = @Content(
           mediaType = MediaType.APPLICATION_JSON_VALUE,
           array = @ArraySchema(schema = @Schema(implementation = LabPublicKeyInfo.class)))),
-      @ApiResponse(responseCode = "500", description = "Internal Server Error")
+      @ApiResponse(responseCode = "500", description = "Internal Server Error"),
+      @ApiResponse(responseCode = "403", description = "LabId is not or cannot be assigned to Partner.")
     })
   @GetMapping("/search/{labId}")
   public ResponseEntity<List<LabPublicKeyInfo>> searchPublicKeys(
+    @Valid @Pattern(regexp = "^[A-Za-z0-9]{1,64}$") @RequestHeader("X-CWA-PARTNER-ID") String partnerId,
     @PathVariable("labId") String labId) {
+
+    if (!labIdClaimService.getClaim(partnerId, labId)) {
+      throw new DccServerException(HttpStatus.FORBIDDEN, "Failed to claim LabId");
+    }
 
     List<LabPublicKeyInfo> resultList = dccRegistrationService.findPendingDccByLabId(labId).stream()
       .map(this::convert)

--- a/src/main/java/app/coronawarn/dcc/domain/LabIdClaim.java
+++ b/src/main/java/app/coronawarn/dcc/domain/LabIdClaim.java
@@ -58,7 +58,7 @@ public class LabIdClaim implements Serializable {
   private LocalDateTime createdAt;
 
   @Column(name = "last_used")
-  private LocalDateTime lastUsedt;
+  private LocalDateTime lastUsed;
 
   @Column(name = "lab_id")
   private String labId;

--- a/src/main/java/app/coronawarn/dcc/domain/LabIdClaim.java
+++ b/src/main/java/app/coronawarn/dcc/domain/LabIdClaim.java
@@ -69,6 +69,7 @@ public class LabIdClaim implements Serializable {
   @PrePersist
   public void prePersist() {
     createdAt = LocalDateTime.now();
+    lastUsed = LocalDateTime.now();
   }
 
 }

--- a/src/main/java/app/coronawarn/dcc/domain/LabIdClaim.java
+++ b/src/main/java/app/coronawarn/dcc/domain/LabIdClaim.java
@@ -1,0 +1,74 @@
+/*-
+ * ---license-start
+ * Corona-Warn-App / cwa-dcc
+ * ---
+ * Copyright (C) 2020 - 2021 T-Systems International GmbH and all other contributors
+ * ---
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ---license-end
+ */
+
+package app.coronawarn.dcc.domain;
+
+import java.io.Serializable;
+import java.time.LocalDateTime;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.PrePersist;
+import javax.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * This class represents the LabIdClaim-entity.
+ */
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "lab_id_claim")
+@Builder
+@Getter
+@Setter
+public class LabIdClaim implements Serializable {
+
+  private static final long serialVersionUID = 1L;
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "id")
+  private Long id;
+
+  @Column(name = "created_at")
+  private LocalDateTime createdAt;
+
+  @Column(name = "last_used")
+  private LocalDateTime lastUsedt;
+
+  @Column(name = "lab_id")
+  private String labId;
+
+  @Column(name = "partner_id")
+  private String partnerId;
+
+  @PrePersist
+  public void prePersist() {
+    createdAt = LocalDateTime.now();
+  }
+
+}

--- a/src/main/java/app/coronawarn/dcc/model/LabIdClaimRequest.java
+++ b/src/main/java/app/coronawarn/dcc/model/LabIdClaimRequest.java
@@ -1,0 +1,41 @@
+/*-
+ * ---license-start
+ * Corona-Warn-App / cwa-dcc
+ * ---
+ * Copyright (C) 2020 - 2021 T-Systems International GmbH and all other contributors
+ * ---
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ---license-end
+ */
+
+package app.coronawarn.dcc.model;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import javax.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Schema(
+  description = "Request payload to claim a LabId."
+)
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class LabIdClaimRequest {
+
+  @Schema(description = "LabId to claim.")
+  @Pattern(regexp = "^[A-Za-z0-9]{1,64}$")
+  private String labId;
+
+}

--- a/src/main/java/app/coronawarn/dcc/repository/LabIdClaimRepository.java
+++ b/src/main/java/app/coronawarn/dcc/repository/LabIdClaimRepository.java
@@ -14,7 +14,7 @@ public interface LabIdClaimRepository extends JpaRepository<LabIdClaim, Long> {
 
   int countByPartnerId(String partnerId);
 
-  Optional<LabIdClaim> findByPartnerIdAndLabId(String partnerId, String labId);
+  Optional<LabIdClaim> findByLabId(String labId);
 
   @Modifying
   @Query("UPDATE LabIdClaim l SET l.lastUsed = current_timestamp WHERE l = :claim")
@@ -22,6 +22,6 @@ public interface LabIdClaimRepository extends JpaRepository<LabIdClaim, Long> {
 
   @Modifying
   @Query("DELETE FROM LabIdClaim l WHERE l.lastUsed < :timestamp")
-  void deleteClaimsOlderThan(@Param("timestamp") LocalDateTime timestamp);
+  int deleteClaimsOlderThan(@Param("timestamp") LocalDateTime timestamp);
 
 }

--- a/src/main/java/app/coronawarn/dcc/repository/LabIdClaimRepository.java
+++ b/src/main/java/app/coronawarn/dcc/repository/LabIdClaimRepository.java
@@ -1,0 +1,27 @@
+package app.coronawarn.dcc.repository;
+
+import app.coronawarn.dcc.domain.LabIdClaim;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import javax.transaction.Transactional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+@Transactional
+public interface LabIdClaimRepository extends JpaRepository<LabIdClaim, Long> {
+
+  int countByPartnerId(String partnerId);
+
+  Optional<LabIdClaim> findByPartnerIdAndLabId(String partnerId, String labId);
+
+  @Modifying
+  @Query("UPDATE LabIdClaim l SET l.lastUsed = current_timestamp WHERE l = :claim")
+  void updateLastUsed(@Param("claim") LabIdClaim claim);
+
+  @Modifying
+  @Query("DELETE FROM LabIdClaim l WHERE l.lastUsed < :timestamp")
+  void deleteClaimsOlderThan(@Param("timestamp") LocalDateTime timestamp);
+
+}

--- a/src/main/java/app/coronawarn/dcc/repository/LabIdClaimRepository.java
+++ b/src/main/java/app/coronawarn/dcc/repository/LabIdClaimRepository.java
@@ -1,3 +1,23 @@
+/*-
+ * ---license-start
+ * Corona-Warn-App / cwa-dcc
+ * ---
+ * Copyright (C) 2020 - 2021 T-Systems International GmbH and all other contributors
+ * ---
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ---license-end
+ */
+
 package app.coronawarn.dcc.repository;
 
 import app.coronawarn.dcc.domain.LabIdClaim;

--- a/src/main/java/app/coronawarn/dcc/service/LabIdClaimCleanupService.java
+++ b/src/main/java/app/coronawarn/dcc/service/LabIdClaimCleanupService.java
@@ -1,0 +1,57 @@
+/*-
+ * ---license-start
+ * Corona-Warn-App / cwa-dcc
+ * ---
+ * Copyright (C) 2020 - 2021 T-Systems International GmbH and all other contributors
+ * ---
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ---license-end
+ */
+
+package app.coronawarn.dcc.service;
+
+import app.coronawarn.dcc.config.DccApplicationConfig;
+import app.coronawarn.dcc.repository.LabIdClaimRepository;
+import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class LabIdClaimCleanupService {
+
+  private final LabIdClaimRepository labIdClaimRepository;
+
+  private final DccApplicationConfig config;
+
+  /**
+   * Cleanup Job to remove LabId claims which are not used anymore by partners.
+   */
+  @Scheduled(fixedDelayString = "${cwa.dcc.cleanup.rate:1800000}")
+  @SchedulerLock(name = "labidclaim_cleanup_job")
+  public void cleanup() {
+    log.info("Start LabId Claim Cleanup...");
+
+    LocalDateTime threshold = LocalDateTime.now().minus(config.getLabIdClaim().getMaximumAge(), ChronoUnit.DAYS);
+    int deleteCount = labIdClaimRepository.deleteClaimsOlderThan(threshold);
+    log.info("Deleted {} Lab ID Claims", deleteCount);
+
+    log.info("Finished LabId Claim Cleanup.");
+  }
+
+}

--- a/src/main/java/app/coronawarn/dcc/service/LabIdClaimService.java
+++ b/src/main/java/app/coronawarn/dcc/service/LabIdClaimService.java
@@ -1,5 +1,6 @@
 package app.coronawarn.dcc.service;
 
+import app.coronawarn.dcc.config.DccApplicationConfig;
 import app.coronawarn.dcc.domain.LabIdClaim;
 import app.coronawarn.dcc.repository.LabIdClaimRepository;
 import java.util.Optional;
@@ -14,6 +15,8 @@ public class LabIdClaimService {
 
   private final LabIdClaimRepository labIdClaimRepository;
 
+  private final DccApplicationConfig config;
+
   /**
    * Checks if Claim already exists. If not creates a new one if quota is not already exceeded.
    *
@@ -24,18 +27,54 @@ public class LabIdClaimService {
   public boolean getClaim(String partnerId, String labId) {
     log.debug("Trying to get claim for partnerId {} and labId {}", partnerId, labId);
 
-    Optional<LabIdClaim> claim = labIdClaimRepository.findByPartnerIdAndLabId(partnerId, labId);
+    Optional<LabIdClaim> claim = labIdClaimRepository.findByLabId(labId);
 
-    if (claim.isPresent()) {
+    if (claim.isPresent() && claim.get().getPartnerId().equals(partnerId)) {
       log.debug("Found Claim for partnerId {} and labId {} with ID {}", partnerId, labId, claim.get().getId());
       labIdClaimRepository.updateLastUsed(claim.get());
       return true;
+    } else if (claim.isPresent()) {
+      log.debug("Found Claim for labId {} but for partner ID {} != {}", labId, claim.get().getPartnerId(), partnerId);
+      return false;
     }
 
-    log.debug("Could not find existing claim for partnerId {} and labID {}", partnerId, labId);
+    log.debug("Could not find existing claim for labID {}", labId);
 
     int claimsOfPartnerID = labIdClaimRepository.countByPartnerId(partnerId);
+    if (claimsOfPartnerID >= config.getLabIdClaim().getClaimsPerPartner()) {
+      log.info("Partner with ID {} has exceeded labId limit", partnerId);
+      return false;
+    }
+
+    LabIdClaim newClaim = LabIdClaim.builder()
+      .labId(labId)
+      .partnerId(partnerId)
+      .build();
+
+    labIdClaimRepository.save(newClaim);
+
+    log.debug("Created new claim for Partner ID {} and Lab ID {}", partnerId, labId);
 
     return true;
+  }
+
+  /**
+   * Gets the amount of remaining LabId Claims a Partner can claim.
+   *
+   * @param partnerId the partner Id
+   * @return the amount of remaining claims.
+   */
+  public int getRemainingClaims(String partnerId) {
+    return config.getLabIdClaim().getClaimsPerPartner() - labIdClaimRepository.countByPartnerId(partnerId);
+  }
+
+  /**
+   * Returns the LabIdClaim Entity.
+   *
+   * @param labId to search
+   * @return The entity.
+   */
+  public Optional<LabIdClaim> getClaimEntity(String labId) {
+    return labIdClaimRepository.findByLabId(labId);
   }
 }

--- a/src/main/java/app/coronawarn/dcc/service/LabIdClaimService.java
+++ b/src/main/java/app/coronawarn/dcc/service/LabIdClaimService.java
@@ -1,3 +1,23 @@
+/*-
+ * ---license-start
+ * Corona-Warn-App / cwa-dcc
+ * ---
+ * Copyright (C) 2020 - 2021 T-Systems International GmbH and all other contributors
+ * ---
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * ---license-end
+ */
+
 package app.coronawarn.dcc.service;
 
 import app.coronawarn.dcc.config.DccApplicationConfig;
@@ -16,14 +36,6 @@ public class LabIdClaimService {
   private final LabIdClaimRepository labIdClaimRepository;
 
   private final DccApplicationConfig config;
-
-  /**
-   * Checks if Claim already exists. If not creates a new one if quota is not already exceeded.
-   *
-   * @param partnerId the partner ID
-   * @param labId     the lab ID
-   * @return true if claiming was successful, false if not.
-   */
   public boolean getClaim(String partnerId, String labId) {
     log.debug("Trying to get claim for partnerId {} and labId {}", partnerId, labId);
 

--- a/src/main/java/app/coronawarn/dcc/service/LabIdClaimService.java
+++ b/src/main/java/app/coronawarn/dcc/service/LabIdClaimService.java
@@ -36,6 +36,14 @@ public class LabIdClaimService {
   private final LabIdClaimRepository labIdClaimRepository;
 
   private final DccApplicationConfig config;
+
+  /**
+   * Checks if Claim already exists. If not creates a new one if quota is not already exceeded.
+   *
+   * @param partnerId the partner ID
+   * @param labId     the lab ID
+   * @return true if claiming was successful, false if not.
+   */
   public boolean getClaim(String partnerId, String labId) {
     log.debug("Trying to get claim for partnerId {} and labId {}", partnerId, labId);
 

--- a/src/main/java/app/coronawarn/dcc/service/LabIdClaimService.java
+++ b/src/main/java/app/coronawarn/dcc/service/LabIdClaimService.java
@@ -1,0 +1,41 @@
+package app.coronawarn.dcc.service;
+
+import app.coronawarn.dcc.domain.LabIdClaim;
+import app.coronawarn.dcc.repository.LabIdClaimRepository;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class LabIdClaimService {
+
+  private final LabIdClaimRepository labIdClaimRepository;
+
+  /**
+   * Checks if Claim already exists. If not creates a new one if quota is not already exceeded.
+   *
+   * @param partnerId the partner ID
+   * @param labId     the lab ID
+   * @return true if claiming was successful, false if not.
+   */
+  public boolean getClaim(String partnerId, String labId) {
+    log.debug("Trying to get claim for partnerId {} and labId {}", partnerId, labId);
+
+    Optional<LabIdClaim> claim = labIdClaimRepository.findByPartnerIdAndLabId(partnerId, labId);
+
+    if (claim.isPresent()) {
+      log.debug("Found Claim for partnerId {} and labId {} with ID {}", partnerId, labId, claim.get().getId());
+      labIdClaimRepository.updateLastUsed(claim.get());
+      return true;
+    }
+
+    log.debug("Could not find existing claim for partnerId {} and labID {}", partnerId, labId);
+
+    int claimsOfPartnerID = labIdClaimRepository.countByPartnerId(partnerId);
+
+    return true;
+  }
+}

--- a/src/main/resources/db/changelog.yml
+++ b/src/main/resources/db/changelog.yml
@@ -14,3 +14,6 @@ databaseChangeLog:
   - include:
       file: changelog/v004-increase-dek-column-size.yml
       relativeToChangelogFile: true
+  - include:
+      file: changelog/v005-create-lab-id-claim-table.yml
+      relativeToChangelogFile: true

--- a/src/main/resources/db/changelog/v005-create-lab-id-claim-table.yml
+++ b/src/main/resources/db/changelog/v005-create-lab-id-claim-table.yml
@@ -1,0 +1,55 @@
+databaseChangeLog:
+  - changeSet:
+      id: create-lab-id-claim-table
+      author: f11h
+      changes:
+        - createTable:
+            tableName: lab_id_claim
+            columns:
+              - column:
+                  name: id
+                  type: bigint
+                  autoIncrement: true
+                  startWith: 1
+                  incrementBy: 1
+                  constraints:
+                    unique: true
+                    nullable: false
+                    primaryKey: true
+              - column:
+                  name: created_at
+                  type: datetime
+                  constraints:
+                    nullable: false
+              - column:
+                  name: last_used
+                  type: datetime
+                  constraints:
+                    nullable: false
+              - column:
+                  name: lab_id
+                  type: varchar(64)
+                  constraints:
+                    nullable: false
+                    unique: true
+              - column:
+                  name: partner_id
+                  type: varchar(64)
+                  constraints:
+                    nullable: false
+  - changeSet:
+      id: create-lab-id-claim-indexes
+      author: f11h
+      changes:
+        - createIndex:
+            tableName: lab_id_claim
+            indexName: idx_lab_id_claim_lab_id
+            columns:
+              - column:
+                  name: lab_id
+        - createIndex:
+            tableName: lab_id_claim
+            indexName: idx_lab_id_claim_partner_id
+            columns:
+              - column:
+                  name: partner_id


### PR DESCRIPTION
This PR adds the LabId Pinning feature.
After the first usage a LabId is claimed to a partner id. This prevents partners to upload DCC for other labs.

The LabId Claim will be deleted after a configurable amount of days when not used. (default 30)

There is also a limit of LabIds a partner can claim (default 100)