### PR TITLE
Fix: Possible Race Condition when Signing DCC

### DIFF
--- a/src/main/java/app/coronawarn/dcc/controller/InternalDccController.java
+++ b/src/main/java/app/coronawarn/dcc/controller/InternalDccController.java
@@ -116,12 +116,10 @@ public class InternalDccController {
       throw new DccServerException(HttpStatus.BAD_REQUEST, "Invalid Base64 in DEK or encrypted DCC.");
     }
 
-    dccRegistrationService.updateDccRegistration(
-      dccRegistration,
-      uploadRequest.getDccHash(),
-      uploadRequest.getEncryptedDcc(),
-      uploadRequest.getDataEncryptionKey(),
-      partnerId);
+    dccRegistration.setDccHash(uploadRequest.getDccHash());
+    dccRegistration.setDccEncryptedPayload(uploadRequest.getEncryptedDcc());
+    dccRegistration.setEncryptedDataEncryptionKey(uploadRequest.getDataEncryptionKey());
+    dccRegistration.setPartnerId(partnerId);
 
     try {
       dccRegistration = dccService.sign(dccRegistration);
@@ -139,6 +137,13 @@ public class InternalDccController {
         .status(HttpStatus.INTERNAL_SERVER_ERROR)
         .body(new DccUnexpectedError(dccRegistration.getError()));
     }
+
+    dccRegistrationService.updateDccRegistration(
+      dccRegistration,
+      uploadRequest.getDccHash(),
+      uploadRequest.getEncryptedDcc(),
+      uploadRequest.getDataEncryptionKey(),
+      partnerId);
 
     return ResponseEntity.ok(new DccUploadResponse(dccRegistration.getDcc()));
   }

--- a/src/main/java/app/coronawarn/dcc/service/DccRegistrationService.java
+++ b/src/main/java/app/coronawarn/dcc/service/DccRegistrationService.java
@@ -36,6 +36,7 @@ import java.security.spec.X509EncodedKeySpec;
 import java.util.Base64;
 import java.util.List;
 import java.util.Optional;
+import javax.validation.constraints.NotNull;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -133,24 +134,30 @@ public class DccRegistrationService {
 
   /**
    * Sets the Error Property on a DCC Registration and saves it into DB.
+   * This method also deletes previously saved DCC details from entity.
    *
    * @param registration The target DCC Registration
    * @param reason       the new Error Reason
    * @return the updated Registration Entity
    */
   public DccRegistration setError(DccRegistration registration, DccErrorReason reason) {
+    registration.setDcc(null);
+    registration.setDccHash(null);
+    registration.setPartnerId(null);
+    registration.setEncryptedDataEncryptionKey(null);
     registration.setError(reason);
     return dccRegistrationRepository.save(registration);
   }
 
   /**
-   * Sets the DCC Property on a DCC Registration and saves it into DB.
+   * Sets the DCC Property and resets error on a DCC Registration and saves it into DB.
    *
    * @param registration The target DCC Registration
    * @param dcc          the base64 encoded DCC
    * @return the updated Registration Entity
    */
-  public DccRegistration setDcc(DccRegistration registration, String dcc) {
+  public DccRegistration setDcc(DccRegistration registration, @NotNull String dcc) {
+    registration.setError(null);
     registration.setDcc(dcc);
     return dccRegistrationRepository.save(registration);
   }

--- a/src/main/java/app/coronawarn/dcc/service/DccService.java
+++ b/src/main/java/app/coronawarn/dcc/service/DccService.java
@@ -71,14 +71,7 @@ public class DccService {
       }
     }
 
-    registration = dccRegistrationService.setDcc(registration, Base64.getEncoder().encodeToString(coseBytes));
-
-    // Reset Error if everything is ok and it previously exists
-    if (registration.getError() != null) {
-      dccRegistrationService.setError(registration, null);
-    }
-
-    return registration;
+    return dccRegistrationService.setDcc(registration, Base64.getEncoder().encodeToString(coseBytes));
   }
 
   private byte[] callSigningApiWithRetry(String hashBase64) {

--- a/src/test/java/app/coronawarn/dcc/service/DccServiceTest.java
+++ b/src/test/java/app/coronawarn/dcc/service/DccServiceTest.java
@@ -204,6 +204,11 @@ public class DccServiceTest {
     Assertions.assertEquals(DccErrorReason.SIGNING_SERVER_ERROR, registrationWithFailedSigning.getError());
     Assertions.assertNull(registrationWithFailedSigning.getDcc());
 
+    registrationWithFailedSigning.setDccHash(dccHash);
+    registrationWithFailedSigning.setDccEncryptedPayload(Base64.getEncoder().encodeToString(encryptedDcc));
+    registrationWithFailedSigning.setEncryptedDataEncryptionKey(Base64.getEncoder().encodeToString(encryptedDek));
+    registrationWithFailedSigning.setPartnerId(partnerId);
+
     Assertions.assertDoesNotThrow(() -> dccService.sign(registrationWithFailedSigning));
 
     registration = dccRegistrationService.findByRegistrationToken(registrationTokenValue).orElseThrow();


### PR DESCRIPTION
When an APP is downloading a DCC between the two events: LAB is uploading DCC and waiting for response AND UBirch API is responding to signing request the DCC Claim API responds with a 410 Gone.

This PR fixes the problem and the app will get a 202 until the signing api has responded.