### PR TITLE
feat: add Location-Id and Transaction-Id Header for UBirch API

### DIFF
--- a/src/main/java/app/coronawarn/dcc/client/SigningApiClient.java
+++ b/src/main/java/app/coronawarn/dcc/client/SigningApiClient.java
@@ -24,6 +24,7 @@ import org.springframework.cloud.openfeign.FeignClient;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 
 /**
  * This class represents the Verification Server Feign client.
@@ -44,5 +45,5 @@ public interface SigningApiClient {
     consumes = MediaType.TEXT_PLAIN_VALUE,
     produces = MediaType.APPLICATION_CBOR_VALUE
   )
-  byte[] sign(@RequestBody String hash);
+  byte[] sign(@RequestBody String hash, @RequestHeader("<<LAB ID REQUEST HEADER>>") String labId);
 }

--- a/src/main/java/app/coronawarn/dcc/client/SigningApiClient.java
+++ b/src/main/java/app/coronawarn/dcc/client/SigningApiClient.java
@@ -45,5 +45,8 @@ public interface SigningApiClient {
     consumes = MediaType.TEXT_PLAIN_VALUE,
     produces = MediaType.APPLICATION_CBOR_VALUE
   )
-  byte[] sign(@RequestBody String hash, @RequestHeader("<<LAB ID REQUEST HEADER>>") String labId);
+  byte[] sign(
+    @RequestBody String hash,
+    @RequestHeader("X-Location-Id") String labIdHash,
+    @RequestHeader("X-Transaction-Id") String dcciHash);
 }

--- a/src/main/java/app/coronawarn/dcc/client/SigningApiClientConfig.java
+++ b/src/main/java/app/coronawarn/dcc/client/SigningApiClientConfig.java
@@ -74,7 +74,7 @@ public class SigningApiClientConfig {
 
     List<BasicHeader> headers = new ArrayList<>();
 
-    if (config.getSigningApiServer().getApiKey() != null) {
+    if (!config.getSigningApiServer().getApiKey().isEmpty()) {
       headers.add(
         new BasicHeader(HttpHeaders.AUTHORIZATION, "Bearer " + config.getSigningApiServer().getApiKey()));
     }

--- a/src/main/java/app/coronawarn/dcc/service/DccService.java
+++ b/src/main/java/app/coronawarn/dcc/service/DccService.java
@@ -58,7 +58,7 @@ public class DccService {
       byte[] hashBytes = Hex.decode(registration.getDccHash());
       String hashBase64 = Base64.getEncoder().encodeToString(hashBytes);
 
-      coseBytes = callSigningApiWithRetry(hashBase64);
+      coseBytes = callSigningApiWithRetry(hashBase64, registration.getLabId());
     } catch (FeignException e) {
       log.error("Failed to sign DCC. Http Status Code: {}, Message: {}", e.status(), e.getMessage());
 
@@ -81,12 +81,12 @@ public class DccService {
     return registration;
   }
 
-  private byte[] callSigningApiWithRetry(String hashBase64) {
+  private byte[] callSigningApiWithRetry(String hashBase64, String labId) {
     try {
-      return signingApiClient.sign(hashBase64);
+      return signingApiClient.sign(hashBase64, labId);
     } catch (FeignException e) {
       log.info("First try of calling Signing API failed. Status Code: {}, Message: {}", e.status(), e.getMessage());
-      return signingApiClient.sign(hashBase64);
+      return signingApiClient.sign(hashBase64, labId);
     }
   }
 

--- a/src/main/java/app/coronawarn/dcc/service/DccService.java
+++ b/src/main/java/app/coronawarn/dcc/service/DccService.java
@@ -42,6 +42,8 @@ public class DccService {
 
   private final SigningApiClient signingApiClient;
 
+  private final HashingService hashingService;
+
   /**
    * Creates signed data for a DCCRegistration.
    * This Endpoints queries the SigningAPI and signs the hash assigned to this Registration.
@@ -58,7 +60,10 @@ public class DccService {
       byte[] hashBytes = Hex.decode(registration.getDccHash());
       String hashBase64 = Base64.getEncoder().encodeToString(hashBytes);
 
-      coseBytes = callSigningApiWithRetry(hashBase64, registration.getLabId());
+      coseBytes = callSigningApiWithRetry(
+        hashBase64,
+        hashingService.hash(registration.getLabId()),
+        hashingService.hash(registration.getDcci()));
     } catch (FeignException e) {
       log.error("Failed to sign DCC. Http Status Code: {}, Message: {}", e.status(), e.getMessage());
 
@@ -81,12 +86,12 @@ public class DccService {
     return registration;
   }
 
-  private byte[] callSigningApiWithRetry(String hashBase64, String labId) {
+  private byte[] callSigningApiWithRetry(String hashBase64, String hashedLabId, String hashedDcci) {
     try {
-      return signingApiClient.sign(hashBase64, labId);
+      return signingApiClient.sign(hashBase64, hashedLabId, hashedDcci);
     } catch (FeignException e) {
       log.info("First try of calling Signing API failed. Status Code: {}, Message: {}", e.status(), e.getMessage());
-      return signingApiClient.sign(hashBase64, labId);
+      return signingApiClient.sign(hashBase64, hashedLabId, hashedDcci);
     }
   }
 

--- a/src/main/resources/application-cloud.yml
+++ b/src/main/resources/application-cloud.yml
@@ -43,9 +43,9 @@ cwa:
       key-store-password: ${CWA_DCC_SIGNINGAPISERVER_KEYSTOREPASSWORD}
       trust-store-password: ${CWA_DCC_SIGNINGAPISERVER_TRUSTSTOREPASSWORD}
       trust-store-path: ${CWA_DCC_SIGNINGAPISERVER_TRUSTSTOREPATH}
-      api-key: ${CWA_DCC_SIGNINGAPISERVER_APIKEY}
+      api-key: ${CWA_DCC_SIGNINGAPISERVER_APIKEY:}
       verify-hostnames: true
-      connection-close-workaround: ${CWA_DCC_SIGNINGAPISERVER_CONNECTIONCLOSEWORKAROUND}
+      connection-close-workaround: ${CWA_DCC_SIGNINGAPISERVER_CONNECTIONCLOSEWORKAROUND:false}
     request:
       sizelimit: 10000
     entities:

--- a/src/test/java/app/coronawarn/dcc/controller/InternalDccControllerTest.java
+++ b/src/test/java/app/coronawarn/dcc/controller/InternalDccControllerTest.java
@@ -103,7 +103,7 @@ public class InternalDccControllerTest {
     when(verificationServerClientMock.result(eq(registrationToken)))
       .thenReturn(new InternalTestResult(6, labId, testId, 0));
 
-    when(signingApiClientMock.sign(eq(dccHashBase64)))
+    when(signingApiClientMock.sign(eq(dccHashBase64), eq(labId)))
       .thenReturn(partialDcc);
   }
 
@@ -123,7 +123,7 @@ public class InternalDccControllerTest {
       .andExpect(status().isOk())
       .andExpect(jsonPath("$.partialDcc").value(equalTo(partialDccBase64)));
 
-    verify(signingApiClientMock).sign(eq(dccHashBase64));
+    verify(signingApiClientMock).sign(eq(dccHashBase64), eq(labId));
 
     Optional<DccRegistration> dccRegistration = dccRegistrationRepository.findByRegistrationToken(registrationTokenValue);
 
@@ -147,7 +147,7 @@ public class InternalDccControllerTest {
     )
       .andExpect(status().isNotFound());
 
-    verify(signingApiClientMock, never()).sign(eq(dccHashBase64));
+    verify(signingApiClientMock, never()).sign(eq(dccHashBase64), eq(labId));
   }
 
   @Test
@@ -166,7 +166,7 @@ public class InternalDccControllerTest {
     )
       .andExpect(status().isForbidden());
 
-    verify(signingApiClientMock, never()).sign(eq(dccHashBase64));
+    verify(signingApiClientMock, never()).sign(eq(dccHashBase64), eq(labId));
   }
 
   @Test
@@ -186,7 +186,7 @@ public class InternalDccControllerTest {
     )
       .andExpect(status().isConflict());
 
-    verify(signingApiClientMock, never()).sign(eq(dccHashBase64));
+    verify(signingApiClientMock, never()).sign(eq(dccHashBase64), eq(labId));
   }
 
   @Test
@@ -202,7 +202,7 @@ public class InternalDccControllerTest {
     )
       .andExpect(status().isBadRequest());
 
-    verify(signingApiClientMock, never()).sign(eq(dccHashBase64));
+    verify(signingApiClientMock, never()).sign(eq(dccHashBase64), eq(labId));
   }
 
   @Test
@@ -218,7 +218,7 @@ public class InternalDccControllerTest {
     )
       .andExpect(status().isBadRequest());
 
-    verify(signingApiClientMock, never()).sign(eq(dccHashBase64));
+    verify(signingApiClientMock, never()).sign(eq(dccHashBase64), eq(labId));
   }
 
   @Test
@@ -228,7 +228,7 @@ public class InternalDccControllerTest {
     DccUploadRequest dccUploadRequest = new DccUploadRequest(dccHash, encryptedDccBase64, encryptedDekBase64);
 
     doThrow(new FeignException.BadRequest("", dummyRequest, null))
-      .when(signingApiClientMock).sign(eq(dccHashBase64));
+      .when(signingApiClientMock).sign(eq(dccHashBase64), eq(labId));
 
     mockMvc.perform(post("/version/v1/test/" + testId + "/dcc")
       .contentType(MediaType.APPLICATION_JSON_VALUE)
@@ -254,7 +254,7 @@ public class InternalDccControllerTest {
     DccUploadRequest dccUploadRequest = new DccUploadRequest(dccHash, encryptedDccBase64, encryptedDekBase64);
 
     doThrow(new FeignException.InternalServerError("", dummyRequest, null))
-      .when(signingApiClientMock).sign(eq(dccHashBase64));
+      .when(signingApiClientMock).sign(eq(dccHashBase64), eq(labId));
 
     mockMvc.perform(post("/version/v1/test/" + testId + "/dcc")
       .contentType(MediaType.APPLICATION_JSON_VALUE)

--- a/src/test/java/app/coronawarn/dcc/service/DccServiceTest.java
+++ b/src/test/java/app/coronawarn/dcc/service/DccServiceTest.java
@@ -80,7 +80,7 @@ public class DccServiceTest {
   void testSigning() throws NoSuchAlgorithmException, DccRegistrationService.DccRegistrationException {
 
     when(verificationServerClientMock.result(eq(registrationToken))).thenReturn(new InternalTestResult(6, labId, testId, 0));
-    when(signingApiClient.sign(eq(Base64.getEncoder().encodeToString(Hex.decode(dccHash))))).thenReturn(partialDcc);
+    when(signingApiClient.sign(eq(Base64.getEncoder().encodeToString(Hex.decode(dccHash))), eq(labId))).thenReturn(partialDcc);
 
     PublicKey publicKey = TestUtils.generateKeyPair().getPublic();
     DccRegistration registration = dccRegistrationService.createDccRegistration(registrationTokenValue, publicKey);
@@ -105,7 +105,7 @@ public class DccServiceTest {
     when(verificationServerClientMock.result(eq(registrationToken))).thenReturn(new InternalTestResult(6, labId, testId, 0));
 
     doThrow(new FeignException.BadRequest("", dummyRequest, null))
-      .when(signingApiClient).sign(eq(Base64.getEncoder().encodeToString(Hex.decode(dccHash))));
+      .when(signingApiClient).sign(eq(Base64.getEncoder().encodeToString(Hex.decode(dccHash))), eq(labId));
 
     PublicKey publicKey = TestUtils.generateKeyPair().getPublic();
     DccRegistration registration = dccRegistrationService.createDccRegistration(registrationTokenValue, publicKey);
@@ -131,7 +131,7 @@ public class DccServiceTest {
     when(verificationServerClientMock.result(eq(registrationToken))).thenReturn(new InternalTestResult(6, labId, testId, 0));
 
     doThrow(new FeignException.InternalServerError("", dummyRequest, null))
-      .when(signingApiClient).sign(eq(Base64.getEncoder().encodeToString(Hex.decode(dccHash))));
+      .when(signingApiClient).sign(eq(Base64.getEncoder().encodeToString(Hex.decode(dccHash))), eq(labId));
 
     PublicKey publicKey = TestUtils.generateKeyPair().getPublic();
     DccRegistration registration = dccRegistrationService.createDccRegistration(registrationTokenValue, publicKey);
@@ -158,7 +158,7 @@ public class DccServiceTest {
 
     doThrow(new FeignException.InternalServerError("", dummyRequest, null))
       .doReturn(partialDcc)
-      .when(signingApiClient).sign(eq(Base64.getEncoder().encodeToString(Hex.decode(dccHash))));
+      .when(signingApiClient).sign(eq(Base64.getEncoder().encodeToString(Hex.decode(dccHash))), eq(labId));
 
     PublicKey publicKey = TestUtils.generateKeyPair().getPublic();
     DccRegistration registration = dccRegistrationService.createDccRegistration(registrationTokenValue, publicKey);
@@ -185,7 +185,7 @@ public class DccServiceTest {
     doThrow(new FeignException.InternalServerError("", dummyRequest, null))
       .doThrow(new FeignException.InternalServerError("", dummyRequest, null))
       .doReturn(partialDcc)
-      .when(signingApiClient).sign(eq(Base64.getEncoder().encodeToString(Hex.decode(dccHash))));
+      .when(signingApiClient).sign(eq(Base64.getEncoder().encodeToString(Hex.decode(dccHash))), eq(labId));
 
     PublicKey publicKey = TestUtils.generateKeyPair().getPublic();
     DccRegistration registration = dccRegistrationService.createDccRegistration(registrationTokenValue, publicKey);

--- a/src/test/java/app/coronawarn/dcc/service/DccServiceTest.java
+++ b/src/test/java/app/coronawarn/dcc/service/DccServiceTest.java
@@ -30,6 +30,7 @@ import static app.coronawarn.dcc.utils.TestValues.partnerId;
 import static app.coronawarn.dcc.utils.TestValues.registrationToken;
 import static app.coronawarn.dcc.utils.TestValues.registrationTokenValue;
 import static app.coronawarn.dcc.utils.TestValues.testId;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.when;
@@ -65,6 +66,9 @@ public class DccServiceTest {
   @Autowired
   DccRegistrationRepository dccRegistrationRepository;
 
+  @Autowired
+  HashingService hashingService;
+
   @MockBean
   VerificationServerClient verificationServerClientMock;
 
@@ -80,7 +84,11 @@ public class DccServiceTest {
   void testSigning() throws NoSuchAlgorithmException, DccRegistrationService.DccRegistrationException {
 
     when(verificationServerClientMock.result(eq(registrationToken))).thenReturn(new InternalTestResult(6, labId, testId, 0));
-    when(signingApiClient.sign(eq(Base64.getEncoder().encodeToString(Hex.decode(dccHash))), eq(labId))).thenReturn(partialDcc);
+    when(signingApiClient.sign(
+      eq(Base64.getEncoder().encodeToString(Hex.decode(dccHash))),
+      eq(hashingService.hash(labId)),
+      anyString()
+    )).thenReturn(partialDcc);
 
     PublicKey publicKey = TestUtils.generateKeyPair().getPublic();
     DccRegistration registration = dccRegistrationService.createDccRegistration(registrationTokenValue, publicKey);
@@ -105,7 +113,10 @@ public class DccServiceTest {
     when(verificationServerClientMock.result(eq(registrationToken))).thenReturn(new InternalTestResult(6, labId, testId, 0));
 
     doThrow(new FeignException.BadRequest("", dummyRequest, null))
-      .when(signingApiClient).sign(eq(Base64.getEncoder().encodeToString(Hex.decode(dccHash))), eq(labId));
+      .when(signingApiClient).sign(
+      eq(Base64.getEncoder().encodeToString(Hex.decode(dccHash))),
+      eq(hashingService.hash(labId)),
+      anyString());
 
     PublicKey publicKey = TestUtils.generateKeyPair().getPublic();
     DccRegistration registration = dccRegistrationService.createDccRegistration(registrationTokenValue, publicKey);
@@ -131,7 +142,10 @@ public class DccServiceTest {
     when(verificationServerClientMock.result(eq(registrationToken))).thenReturn(new InternalTestResult(6, labId, testId, 0));
 
     doThrow(new FeignException.InternalServerError("", dummyRequest, null))
-      .when(signingApiClient).sign(eq(Base64.getEncoder().encodeToString(Hex.decode(dccHash))), eq(labId));
+      .when(signingApiClient).sign(
+      eq(Base64.getEncoder().encodeToString(Hex.decode(dccHash))),
+      eq(hashingService.hash((labId))),
+      anyString());
 
     PublicKey publicKey = TestUtils.generateKeyPair().getPublic();
     DccRegistration registration = dccRegistrationService.createDccRegistration(registrationTokenValue, publicKey);
@@ -158,7 +172,10 @@ public class DccServiceTest {
 
     doThrow(new FeignException.InternalServerError("", dummyRequest, null))
       .doReturn(partialDcc)
-      .when(signingApiClient).sign(eq(Base64.getEncoder().encodeToString(Hex.decode(dccHash))), eq(labId));
+      .when(signingApiClient).sign(
+      eq(Base64.getEncoder().encodeToString(Hex.decode(dccHash))),
+      eq(hashingService.hash(labId)),
+      anyString());
 
     PublicKey publicKey = TestUtils.generateKeyPair().getPublic();
     DccRegistration registration = dccRegistrationService.createDccRegistration(registrationTokenValue, publicKey);
@@ -185,7 +202,10 @@ public class DccServiceTest {
     doThrow(new FeignException.InternalServerError("", dummyRequest, null))
       .doThrow(new FeignException.InternalServerError("", dummyRequest, null))
       .doReturn(partialDcc)
-      .when(signingApiClient).sign(eq(Base64.getEncoder().encodeToString(Hex.decode(dccHash))), eq(labId));
+      .when(signingApiClient).sign(
+      eq(Base64.getEncoder().encodeToString(Hex.decode(dccHash))),
+      eq(hashingService.hash(labId)),
+      anyString());
 
     PublicKey publicKey = TestUtils.generateKeyPair().getPublic();
     DccRegistration registration = dccRegistrationService.createDccRegistration(registrationTokenValue, publicKey);


### PR DESCRIPTION
This PR adds the X-Location-Id (SHA256 hash of labId) and X-Transaction-Id (SHA256 hash of DCCI) for requests to UBirch API.