### PR TITLE
Add UBirch Cert-Type Header

### DIFF
--- a/src/main/java/app/coronawarn/dcc/client/SigningApiClientConfig.java
+++ b/src/main/java/app/coronawarn/dcc/client/SigningApiClientConfig.java
@@ -84,6 +84,8 @@ public class SigningApiClientConfig {
       headers.add(new BasicHeader(HttpHeaders.CONNECTION, "Close"));
     }
 
+    headers.add(new BasicHeader("X-UBIRCH-DCCType", "T"));
+
     httpClientBuilder.setDefaultHeaders(headers);
 
     return new ApacheHttpClient(httpClientBuilder.build());


### PR DESCRIPTION
This PR adds the X-UBIRCH-DCCType Header to all outbound Signing API Requests.