### PR TITLE
Fix: Search Pending DCC and Cleanup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <liquibase.version>4.6.2</liquibase.version>
     <springdoc.version>1.6.4</springdoc.version>
     <cbor.version>4.5</cbor.version>
-    <hibernate-validator.version>7.0.2.Final</hibernate-validator.version>
+    <hibernate-validator.version>6.1.5.Final</hibernate-validator.version>
     <shedlock.version>4.30.0</shedlock.version>
     <!-- plugins -->
     <plugin.checkstyle.version>3.1.2</plugin.checkstyle.version>
@@ -215,11 +215,6 @@
       <artifactId>spring-security-core</artifactId>
       <version>${spring-security.version}</version>
       <type>jar</type>
-    </dependency>
-    <dependency>
-      <groupId>org.hibernate.validator</groupId>
-      <artifactId>hibernate-validator</artifactId>
-      <version>${hibernate-validator.version}</version>
     </dependency>
     <dependency>
       <groupId>io.reactivex</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,6 @@
     <liquibase.version>4.6.2</liquibase.version>
     <springdoc.version>1.6.4</springdoc.version>
     <cbor.version>4.5</cbor.version>
-    <hibernate-validator.version>6.1.5.Final</hibernate-validator.version>
     <shedlock.version>4.30.0</shedlock.version>
     <!-- plugins -->
     <plugin.checkstyle.version>3.1.2</plugin.checkstyle.version>

--- a/src/main/java/app/coronawarn/dcc/controller/ExternalPublicKeyController.java
+++ b/src/main/java/app/coronawarn/dcc/controller/ExternalPublicKeyController.java
@@ -97,6 +97,9 @@ public class ExternalPublicKeyController {
       } else if (e.getReason()
         == DccRegistrationService.DccRegistrationException.Reason.REGISTRATION_TOKEN_ALREADY_EXISTS) {
         throw new DccServerException(HttpStatus.CONFLICT, "RegistrationToken is already assigned with a PublicKey.");
+      } else if (e.getReason()
+        == DccRegistrationService.DccRegistrationException.Reason.NO_LAB_ID) {
+        throw new DccServerException(HttpStatus.FORBIDDEN, "Lab has not provided any LabId for this TestResult.");
       } else {
         throw new DccServerException(HttpStatus.INTERNAL_SERVER_ERROR, "Unexpected error");
       }

--- a/src/main/java/app/coronawarn/dcc/repository/DccRegistrationRepository.java
+++ b/src/main/java/app/coronawarn/dcc/repository/DccRegistrationRepository.java
@@ -37,7 +37,7 @@ public interface DccRegistrationRepository extends JpaRepository<DccRegistration
 
   Optional<DccRegistration> findByRegistrationToken(String registrationToken);
 
-  List<DccRegistration> findByLabIdAndDccHashIsNull(String labId);
+  List<DccRegistration> findByLabIdAndDccHashIsNullAndPublicKeyIsNotNull(String labId);
 
   Optional<DccRegistration> findByHashedGuid(String hashedGuid);
 
@@ -48,11 +48,12 @@ public interface DccRegistrationRepository extends JpaRepository<DccRegistration
   @Modifying(clearAutomatically = true, flushAutomatically = true)
   @Query("UPDATE DccRegistration d SET d.dcc = NULL, d.publicKey = NULL, d.encryptedDataEncryptionKey = NULL,"
     + " d.error = NULL, d.hashedGuid = NULL, d.dccEncryptedPayload = NULL"
-    + " WHERE d.updatedAt < :threshold AND d.dcc IS NOT NULL")
+    + " WHERE d.updatedAt < :threshold AND d.publicKey IS NOT NULL")
   int removeDccDataByUpdatedAtBefore(@Param("threshold") LocalDateTime threshold);
 
   @Modifying(clearAutomatically = true, flushAutomatically = true)
-  @Query("UPDATE DccRegistration d SET d.registrationToken = NULL"
+  @Query("UPDATE DccRegistration d SET d.registrationToken = NULL, d.dcc = NULL, d.publicKey = NULL,"
+    + " d.encryptedDataEncryptionKey = NULL, d.error = NULL, d.hashedGuid = NULL, d.dccEncryptedPayload = NULL"
     + " WHERE d.createdAt < :threshold AND d.registrationToken IS NOT NULL")
   int removeRegistrationTokenByCreatedAtBefore(@Param("threshold") LocalDateTime threshold);
 }

--- a/src/main/java/app/coronawarn/dcc/service/DccRegistrationService.java
+++ b/src/main/java/app/coronawarn/dcc/service/DccRegistrationService.java
@@ -194,6 +194,10 @@ public class DccRegistrationService {
       throw new DccRegistrationException(DccRegistrationException.Reason.INVALID_REGISTRATION_TOKEN_FORBIDDEN);
     }
 
+    if (testResult.getLabId() == null) {
+      throw new DccRegistrationException(DccRegistrationException.Reason.NO_LAB_ID);
+    }
+
     return testResult;
   }
 
@@ -247,7 +251,8 @@ public class DccRegistrationService {
       REGISTRATION_TOKEN_ALREADY_EXISTS,
       INVALID_REGISTRATION_TOKEN_NOT_FOUND,
       INVALID_REGISTRATION_TOKEN_FORBIDDEN,
-      VERIFICATION_SERVER_ERROR
+      VERIFICATION_SERVER_ERROR,
+      NO_LAB_ID
     }
   }
 

--- a/src/main/java/app/coronawarn/dcc/service/DccRegistrationService.java
+++ b/src/main/java/app/coronawarn/dcc/service/DccRegistrationService.java
@@ -89,7 +89,7 @@ public class DccRegistrationService {
    * @return List of matching DCC Registrations.
    */
   public List<DccRegistration> findPendingDccByLabId(String labId) {
-    return dccRegistrationRepository.findByLabIdAndDccHashIsNull(labId);
+    return dccRegistrationRepository.findByLabIdAndDccHashIsNullAndPublicKeyIsNotNull(labId);
   }
 
   /**

--- a/src/test/java/app/coronawarn/dcc/controller/ExternalPublicKeyControllerTest.java
+++ b/src/test/java/app/coronawarn/dcc/controller/ExternalPublicKeyControllerTest.java
@@ -27,7 +27,6 @@ import static app.coronawarn.dcc.utils.TestValues.registrationToken;
 import static app.coronawarn.dcc.utils.TestValues.registrationTokenValue;
 import static app.coronawarn.dcc.utils.TestValues.testId;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.when;
@@ -100,9 +99,9 @@ public class ExternalPublicKeyControllerTest {
       registrationTokenValue, publicKeyBase64, "");
 
     mockMvc.perform(post("/version/v1/publicKey")
-      .contentType(MediaType.APPLICATION_JSON_VALUE)
-      .content(new ObjectMapper().writeValueAsString(uploadPublicKeyRequest))
-    )
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .content(new ObjectMapper().writeValueAsString(uploadPublicKeyRequest))
+      )
       .andExpect(status().isCreated());
 
 
@@ -120,9 +119,9 @@ public class ExternalPublicKeyControllerTest {
       registrationTokenValue, publicKeyBase64, "");
 
     mockMvc.perform(post("/version/v1/publicKey")
-      .contentType(MediaType.APPLICATION_JSON_VALUE)
-      .content(new ObjectMapper().writeValueAsString(uploadPublicKeyRequest))
-    )
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .content(new ObjectMapper().writeValueAsString(uploadPublicKeyRequest))
+      )
       .andExpect(status().isBadRequest());
   }
 
@@ -140,12 +139,31 @@ public class ExternalPublicKeyControllerTest {
       .when(verificationServerClientMock).result(eq(registrationToken));
 
     mockMvc.perform(post("/version/v1/publicKey")
-      .contentType(MediaType.APPLICATION_JSON_VALUE)
-      .content(new ObjectMapper().writeValueAsString(uploadPublicKeyRequest))
-    )
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .content(new ObjectMapper().writeValueAsString(uploadPublicKeyRequest))
+      )
       .andExpect(status().isForbidden());
   }
 
+  @Test
+  void testUploadPublicKeyInvalidRegistrationTokenNoLabId() throws Exception {
+    KeyPair keyPair = TestUtils.generateKeyPair();
+    String publicKeyBase64 = Base64.getEncoder().encodeToString(keyPair.getPublic().getEncoded());
+
+    UploadPublicKeyRequest uploadPublicKeyRequest = new UploadPublicKeyRequest(
+      registrationTokenValue, publicKeyBase64, "");
+
+    reset(verificationServerClientMock);
+
+    when(verificationServerClientMock.result(eq(registrationToken)))
+      .thenReturn(new InternalTestResult(6, null, testId, 0));
+
+    mockMvc.perform(post("/version/v1/publicKey")
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .content(new ObjectMapper().writeValueAsString(uploadPublicKeyRequest))
+      )
+      .andExpect(status().isForbidden());
+  }
 
   @Test
   void testUploadPublicKeyInvalidRegistrationTokenNotFound() throws Exception {
@@ -161,9 +179,9 @@ public class ExternalPublicKeyControllerTest {
       .when(verificationServerClientMock).result(eq(registrationToken));
 
     mockMvc.perform(post("/version/v1/publicKey")
-      .contentType(MediaType.APPLICATION_JSON_VALUE)
-      .content(new ObjectMapper().writeValueAsString(uploadPublicKeyRequest))
-    )
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .content(new ObjectMapper().writeValueAsString(uploadPublicKeyRequest))
+      )
       .andExpect(status().isNotFound());
   }
 
@@ -182,9 +200,9 @@ public class ExternalPublicKeyControllerTest {
       .when(verificationServerClientMock).result(eq(registrationToken));
 
     mockMvc.perform(post("/version/v1/publicKey")
-      .contentType(MediaType.APPLICATION_JSON_VALUE)
-      .content(new ObjectMapper().writeValueAsString(uploadPublicKeyRequest))
-    )
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .content(new ObjectMapper().writeValueAsString(uploadPublicKeyRequest))
+      )
       .andExpect(status().isInternalServerError());
   }
 
@@ -199,9 +217,9 @@ public class ExternalPublicKeyControllerTest {
       registrationTokenValue, publicKeyBase64, "");
 
     mockMvc.perform(post("/version/v1/publicKey")
-      .contentType(MediaType.APPLICATION_JSON_VALUE)
-      .content(new ObjectMapper().writeValueAsString(uploadPublicKeyRequest))
-    )
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .content(new ObjectMapper().writeValueAsString(uploadPublicKeyRequest))
+      )
       .andExpect(status().isConflict());
   }
 
@@ -219,9 +237,9 @@ public class ExternalPublicKeyControllerTest {
       .thenReturn(new InternalTestResult(0, labId, testId, 0));
 
     mockMvc.perform(post("/version/v1/publicKey")
-      .contentType(MediaType.APPLICATION_JSON_VALUE)
-      .content(new ObjectMapper().writeValueAsString(uploadPublicKeyRequest))
-    )
+        .contentType(MediaType.APPLICATION_JSON_VALUE)
+        .content(new ObjectMapper().writeValueAsString(uploadPublicKeyRequest))
+      )
       .andExpect(status().isForbidden());
   }
 


### PR DESCRIPTION
This PR fixes the Search Endpoint for pending DCC to return only pending DCC when they still have a PublicKey.
The Cleanup Stage 1 (after 4 days) was improved to cleanup entries even if they do not have a DCC uploaded by the Lab.

Extra: If a Testresult has no assigned Lab ID The DCC Registration will not be accepted.