### PR TITLE
Update Dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,21 +34,22 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <!-- dependencies -->
-    <spring.boot.version>2.6.2</spring.boot.version>
-    <spring-security.version>5.6.1</spring-security.version>
-    <spring.cloud.version>2021.0.0</spring.cloud.version>
+    <spring.boot.version>2.6.4</spring.boot.version>
+    <spring-security.version>5.6.2</spring-security.version>
+    <spring.cloud.version>2021.0.1</spring.cloud.version>
     <lombok.version>1.18.22</lombok.version>
-    <liquibase.version>4.6.2</liquibase.version>
-    <springdoc.version>1.6.4</springdoc.version>
-    <cbor.version>4.5.1</cbor.version>
-    <shedlock.version>4.30.0</shedlock.version>
+    <liquibase.version>4.8.0</liquibase.version>
+    <springdoc.version>1.6.6</springdoc.version>
+    <cbor.version>4.5.2</cbor.version>
+    <shedlock.version>4.33.0</shedlock.version>
+    <psql.version>42.3.3</psql.version>
     <!-- plugins -->
     <plugin.checkstyle.version>3.1.2</plugin.checkstyle.version>
-    <plugin.checkstyle.puppycrawl.version>9.2.1</plugin.checkstyle.puppycrawl.version>
+    <plugin.checkstyle.puppycrawl.version>9.3</plugin.checkstyle.puppycrawl.version>
     <plugin.sonar.version>3.9.1.2184</plugin.sonar.version>
     <plugin.jacoco.version>0.8.7</plugin.jacoco.version>
-    <plugin.surefire.version>2.22.2</plugin.surefire.version>
-    <guava.version>31.0.1-jre</guava.version>
+    <plugin.surefire.version>3.0.0-M5</plugin.surefire.version>
+    <guava.version>31.1-jre</guava.version>
     <license.projectName>Corona-Warn-App / cwa-dcc</license.projectName>
     <license.inceptionYear>2020</license.inceptionYear>
     <license.licenseName>apache_v2</license.licenseName>
@@ -197,6 +198,7 @@
       <groupId>org.postgresql</groupId>
       <artifactId>postgresql</artifactId>
       <scope>runtime</scope>
+      <version>${psql.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -214,11 +216,6 @@
       <artifactId>spring-security-core</artifactId>
       <version>${spring-security.version}</version>
       <type>jar</type>
-    </dependency>
-    <dependency>
-      <groupId>io.reactivex</groupId>
-      <artifactId>rxjava</artifactId>
-      <version>1.3.8</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
bump version:
- spring-boot 2.6.4
- spring security 5.6.2
- liquibase 5.8.0
- springdoc 1.6.6
- shedlock 4.33.0
- guava 31.1-jre