### PR TITLE
Chore: Update CWA-Parent to 1.7

### DIFF
--- a/codestyle/checkstyle.xml
+++ b/codestyle/checkstyle.xml
@@ -282,7 +282,7 @@
                 value="CLASS_DEF, INTERFACE_DEF, ENUM_DEF, METHOD_DEF, CTOR_DEF, VARIABLE_DEF"/>
     </module>
     <module name="JavadocMethod">
-      <property name="scope" value="public"/>
+      <property name="accessModifiers" value="public"/>
       <property name="allowMissingParamTags" value="true"/>
       <property name="allowMissingReturnTag" value="true"/>
       <property name="allowedAnnotations" value="Override, Test"/>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
   <parent>
     <groupId>app.coronawarn</groupId>
     <artifactId>cwa-parent</artifactId>
-    <version>1.6</version>
+    <version>1.7</version>
     <relativePath/>
   </parent>
 


### PR DESCRIPTION
### Update the parent pom (cwa-parent) to the last released version.
  
  This PR will update several dependencies within this project.
  Please do a full integration test before merging this PR.
  
  Also please have a look on the [Release Notes](https://github.com/corona-warn-app/cwa-parent/releases/tag/1.7) of this new CWA-Parent version.